### PR TITLE
Fix: enclose password in quotes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ COMMAND="$COMMAND ${CMD[@]}"
 # Authentication Info
 if [[ ! "${CMD[@]}" =~ .*"--help".* ]]; then
   [ ! -z $USERNAME ] && COMMAND="$COMMAND -username=$USERNAME"
-  [ ! -z $PASSWORD ] && COMMAND="$COMMAND -password=$PASSWORD"
+  [ ! -z $PASSWORD ] && COMMAND="$COMMAND -password=\"$PASSWORD\""
 
   if [[ ! "${CMD[@]}" =~ .*"get_credential_ids".* ]]; then
       [ ! -z $CREDENTIAL_ID ] && COMMAND="${COMMAND} -credential_id=${CREDENTIAL_ID}"


### PR DESCRIPTION
As stated in the documentation: https://www.ssl.com/guide/esigner-codesigntool-command-guide/ when the password includes special characters (that is most of the cases) we need to enclose it in quotes.